### PR TITLE
Adding HilltopServer package to RStudioConnect

### DIFF
--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -177,8 +177,10 @@ Make the following initial settings to this file to set up email, AD, and suppre
 
 Set SenderEmail to the service desk email.
 
-`[Server]`
-`SenderEmail = servicedesk@horizons.govt.nz`
+``` console
+[Server]
+SenderEmail = servicedesk@horizons.govt.nz
+```
 
 -----
 
@@ -188,8 +190,10 @@ Restart RStudio Connect after altering the rstudio-connect.gcfg configuration fi
 ### 4.2 Active Directory
 Adding LDAP authentication is done through setting `Provider  = ldap` under the `[Authentication]` section of the config file.
 
-`[Authentication]`
-`Provider  = ldap`
+``` console
+[Authentication]
+Provider  = ldap
+```
 
 LDAP settings were obtained from IT, and stored in 1Password - search for zRStudioLDAP. Copy these settings to any new instance of RStudio Connect.
 
@@ -202,8 +206,10 @@ Restart RStudio Connect after altering the rstudio-connect.gcfg configuration fi
 ### 4.3 Warning about insecure HTTP connection
 Running RStudio Connect over HTTP, as opposed to HTTPS, results in a red status bar appearing on login. To prevent this message from appearing, add the `NoWarning` setting to the `[HTTP]` part of the config file:
 
-`[HTTP]`
-`NoWarning = true`
+``` console
+[HTTP]
+NoWarning = true
+```
 
 -----
 
@@ -216,7 +222,20 @@ sudo /opt/rstudio-connect/bin/license-manager activate <license code>
 sudo systemctl restart rstudio-connect
 ```
 
-## 6. Production Configuration Settings 
+## 6. Production Configuration Settings
+
+### 6.1 Reverse Proxy - nginx
+
+The default port for RStudio Connect is :3939. This is an issue on the internal wireless network, as only traffic on ports 80, 8080 and 443 are allowed through. The impact of this is that wireless devices cannot connect to RStudio Connect directly, and must use a remote desktop client instead.
+
+To resolve this, a reverse proxy (nginx, apache) can be configured on the Ubuntu box to redirect from port :3939 to port :80. My preference is to use nginx.
+
+
+### 6.2 Setting up nginx
+
+
+
+
 
 ## 7. Setting up HilltopServer package
 HilltopServer is a proprietery software package that handles requests for timeseries data. Accessing timeseries data through HilltopServer is a necessary capability for Horizons.

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -6,7 +6,7 @@
 |Privileges|sudo|
 |Reference| [RStudio Connect: Admin Guide](https://docs.rstudio.com/connect/admin/index.html)|
 |Compiled by|Sean Hodges|
-|Last updated|2019-06-15|
+|Last updated|2019-11-13|
 ## Checklist
 
 - [ ] Install R

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -17,10 +17,30 @@
 - [ ] Adding the HilltopServer package
 - [ ] Adding reverse proxy
 
+
+
 ## 1. Install R
 Administrators of the RStudioConnect box should install the versions of R that they wish to support from source so that user content is run in an environment as close as possible to the development environment. This allows maintenance of multiple versions of R simultaneously and mitigates the risk associated with updating the version of R.
 
-Ensure that the `src` URI's in `sources.list` are uncommmented, as various libraries and packages will need to be built from source. Without this, the `sudo apt-get build-dep` will error.
+Add GPG Key: logged into your Ubuntu 18.04 server as a sudo non-root user, add the relevant GPG key.
+
+```console
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+```
+
+Add the R repository
+```console
+sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+```
+If you’re not using 18.04, find the relevant repository from the R Project Ubuntu list, named for each release.
+
+Update Package Lists
+``` console
+sudo apt update
+sudo apt upgrade
+```
+
+Ensure that the `src` URI's in `/etc/apt/sources.list` are uncommmented, as various libraries and packages will need to be built from source. Without this, the `sudo apt-get build-dep` will error.
 
 To build R from source, first, acquire the build dependencies for R.
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -171,14 +171,25 @@ libv8-dev
 
 RStudio Connect is controlled by the `/etc/rstudio-connect/rstudio-connect.gcfg` configuration file. You will edit this file to make server-wide configuration changes to the system.
 
-Make the following initial settings to this file to set up email and AD.
+Make the following initial settings to this file to set up email, AD, and suppress warnings about insecure connections (site is running over HTTP on Horizons internal network - best practice would be to set up HTTPS).
 
 ### 4.1 Email
 
 Set SenderEmail to the service desk email.
 
+`[Server]`
+`SenderEmail = servicedesk@horizons.govt.nz`
+
+-----
+
+Restart RStudio Connect after altering the rstudio-connect.gcfg configuration file.
+
+
 ### 4.2 Active Directory
 Adding LDAP authentication is done through setting `Provider  = ldap` under the `[Authentication]` section of the config file.
+
+`[Authentication]`
+`Provider  = ldap`
 
 LDAP settings were obtained from IT, and stored in 1Password - search for zRStudioLDAP. Copy these settings to any new instance of RStudio Connect.
 
@@ -187,6 +198,16 @@ LDAP settings were obtained from IT, and stored in 1Password - search for zRStud
 Restart RStudio Connect after altering the rstudio-connect.gcfg configuration file.
 
 `sudo systemctl restart rstudio-connect`
+
+### 4.3 Warning about insecure HTTP connection
+Running RStudio Connect over HTTP, as opposed to HTTPS, results in a red status bar appearing on login. To prevent this message from appearing, add the `NoWarning` setting to the `[HTTP]` part of the config file:
+
+`[HTTP]`
+`NoWarning = true`
+
+-----
+
+Restart RStudio Connect after altering the rstudio-connect.gcfg configuration file.
 
 ## 5. Activate License
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -121,7 +121,7 @@ Typically, the following commands at the console will do the trick:
 
 ```console
 sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full libblas-dev libudunits2-dev libgdal-dev
-sudo apt-get libpack-dev
+sudo apt-get install libpack-dev
 # sudo apt install openjdk-11-jdk ## This was already installed on production environment
 sudo R CMD javareconf
 ```

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -111,6 +111,7 @@ You will use `gdebi` to install Connect and its dependencies. It is installed vi
 sudo apt-get install gdebi-core
 ```
 
+**The instructions below relate to the installation of the 45 day trial version of RStudio Connect. Production version instructions are provided elsewhere**
 You should have a `.deb` installer for RStudio Connect. It can be downloaded from the RStudio website (the link is provided by email when you register for the download). If you only have a link to this file, you can use `wget` to download the file to the current directory.
 
 ```console

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -99,8 +99,9 @@ The following system dependencies are required by many common R packages and nea
 Typically, the following commands at the console will do the trick:
 
 ```console
-sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full libblas-dev libpack-dev libudunits2-dev libgdal-dev
-sudo apt install openjdk-11-jdk
+sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full libblas-dev libudunits2-dev libgdal-dev
+sudo apt-get libpack-dev
+# sudo apt install openjdk-11-jdk ## This was already installed on production environment
 sudo R CMD javareconf
 ```
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -138,7 +138,7 @@ Set SenderEmail to the service desk email.
 ### 4.2 Active Directory
 Adding LDAP authentication is done through setting `Provider  = ldap` under the `[Authentication]` section of the config file.
 
-LDAP settings were obtained from IT, and stored in Password1. Copy these settings to any new instance of RStudio Connect.
+LDAP settings were obtained from IT, and stored in 1Password - search for zRStudioLDAP. Copy these settings to any new instance of RStudio Connect.
 
 -----
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -114,25 +114,9 @@ You will use `gdebi` to install Connect and its dependencies. It is installed vi
 ```console
 sudo apt-get install gdebi-core
 ```
+### 3.1 Software Installation 
 
-**The instructions below relate to the installation of the 45 day trial version of RStudio Connect as at May 2019.**
-You should have a `.deb` installer for RStudio Connect. It can be downloaded from the RStudio website (the link is provided by email when you register for the download). If you only have a link to this file, you can use `wget` to download the file to the current directory.
-
-```console
-cd /tmp
-wget https://<download-url>/rstudio-connect_1.7.2.2-14_amd64.deb
-```
-
-Once the `.deb` file is available locally, run the following command to install RStudio Connect.
-
-```console
-sudo gdebi rstudio-connect_1.7.2.2-14_amd64.deb
-```
-
-This will install Connect into `/opt/rstudio-connect/`, and create a new rstudio-connect user.
-
-**The instructions below relate to the installation of the Commercial version of RStudio Connect as at June 2019.**
-RStudio only provides (as at June 2019) a pre-built binary for the 64-bit architecture. Pre-install checklist:
+RStudio only provides (as at June 2019) a pre-built binary for the 64-bit architecture.
 
 These steps will install RStudio Connect:
 
@@ -148,6 +132,39 @@ sudo gdebi rstudio-connect_1.7.4.2-16_amd64.deb
 ```
 
 This will install Connect into `/opt/rstudio-connect/`, and create a new rstudio-connect user.
+
+### 3.2 Supplemental packages
+
+There are additional system dependencies that may be required for some R packages depending on the types of R packages your users are leveraging. You could consider providing these packages for your users now, or wait until they are requested.
+
+```console
+libgmp10-dev
+libgsl0-dev
+libnetcdf6
+libnetcdf-dev
+netcdf-bin
+libdigest-hmac-perl
+libgmp-dev
+libgmp3-dev
+libgl1-mesa-dev
+libglu1-mesa-dev
+libglpk-dev
+tdsodbc
+freetds-bin
+freetds-common
+freetds-dev
+odbc-postgresql
+libtiff-dev
+libsndfile1
+libsndfile1-dev
+libtiff-dev
+tk8.5
+tk8.5-dev
+tcl8.5
+tcl8.5-dev
+libgsl0-dev
+libv8-dev
+```
 
 
 ## 4. Edit RStudio Connect config file
@@ -171,8 +188,12 @@ Restart RStudio Connect after altering the rstudio-connect.gcfg configuration fi
 
 `sudo systemctl restart rstudio-connect`
 
-## 5. Test deployment
+## 5. Activate License
 
+```console
+sudo /opt/rstudio-connect/bin/license-manager activate <license code>
+sudo systemctl restart rstudio-connect
+```
 
 ## 6. Production Configuration Settings 
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -163,7 +163,12 @@ RStudioConnect expects to compile packages from source, but this is not possible
 
 Add the following section to the config file
 
-`[Packages]
+``` console
+[Packages]
 External = HilltopServer`
+```
 
+Restart the server
+
+`sudo systemctl restart rstudio-connect`
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -133,11 +133,12 @@ Make the following initial settings to this file to set up email and AD.
 
 ### 4.1 Email
 
-*Discuss with IT*
+Set SenderEmail to the service desk email.
 
-### 4.2 Active Directory or SAML?
+### 4.2 Active Directory
+Adding LDAP authentication is done through setting `Provider  = ldap` under the `[Authentication]` section of the config file.
 
-*Discuss with IT*
+LDAP settings were obtained from IT, and stored in Password1. Copy these settings to any new instance of RStudio Connect.
 
 -----
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -87,11 +87,15 @@ The following system dependencies are required by many common R packages and nea
 * `libxml2-dev`
 * `libssl-dev`
 * `texlive-full` # very large dependency, but needed to render PDF documents from R Markdown
+* `libblas-dev`
+* `libpack-dev`
+* `libudunits2-dev`
+* `libgdal`
 
 Typically, the following commands at the console will do the trick:
 
 ```console
-sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full
+sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full libblas-dev libpack-dev libudunits2-dev libgdal
 sudo apt install openjdk-11-jdk
 sudo R CMD javareconf
 ```

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -159,8 +159,9 @@ RStudioConnect expects to compile packages from source, but this is not possible
 
 ### 7.1 Copy the Package
 
-1. Winscp the hilltopserver package to a user folder on the RStudio-Connect box
-2. Set up user libary folders for R packages. Reviewing StackOverflow and other support sites, this documentation will advise using the following location to set this up: `/usr/local/share`. Within this location, create an `rpkgs` directory, and beneath that, directories for each major and minor versions of R.
+1. `scp` the hilltopserver package to a user folder on the RStudio-Connect box. There are a number of methods for achieving this. The simplest is to use WinSCP.
+
+2. Set up user libary folders for R packages. Reviewing StackOverflow and other support sites, this documentation suggests using the following location to set this up: `/usr/local/share` (the documentation assumes this location is being used). Within this location, create an `rpkgs` directory, and beneath that, directories for each major and minor versions of R.
 
 ``` console
 # Example
@@ -181,17 +182,19 @@ sudo cp -r ~/HilltopServer 3.5/
 sudo cp -r ~/HilltopServer 3.6/
 ```
 
-3. Now, for each R environment, edit the `Renviron` files: 
+3. Now, for each R environment, edit the `Renviron` file: 
 
 ``` console
+# Editing for R version 3.4.x
 cd /opt/R/3.4.2/lib/R/etc
 sudo nano Renviron
 ```
 
-Edit the `R_LIBS_USER` variable in the `Renviron` file, ensuring that any other entries for this variable are hashed out.
+Now, edit the `R_LIBS_USER` variable in the `Renviron` file, ensuring that any other entries for this variable are hashed out.
 
 `R_LIBS_USER=${R_LIBS_USERS-'/usr/local/share/rpkgs/3.4'}`
 
+Repeat for each version of R installed, using the appropriate major.minor version numbers.
 
 ### 7.2 Edit the config file
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -159,16 +159,47 @@ RStudioConnect expects to compile packages from source, but this is not possible
 
 ### 7.1 Copy the Package
 
+1. Winscp the hilltopserver package to a user folder on the RStudio-Connect box
+2. Set up user libary folders for R packages. Reviewing StackOverflow and other support sites, this documentation will advise using the following location to set this up: `/usr/local/share`. Within this location, create an `rpkgs` directory, and beneath that, directories for each major and minor versions of R.
+
+``` console
+# Example
+cd /usr/local/share
+sudo mkdir rpkgs
+cd rpkgs
+sudo mkdir 3.4
+sudo mkdir 3.5
+sudo mkdir 3.6
+```
+
+2. For each R version directory that has been created, copy the HilltopServer package across from the user folder
+
+``` console
+# These commands are executed from /usr/local/share/rpkgs
+sudo cp -r ~/HilltopServer 3.4/
+sudo cp -r ~/HilltopServer 3.5/
+sudo cp -r ~/HilltopServer 3.6/
+```
+
+3. Now, for each R environment that is installed, the path to the user libraries needs to be updated. 
+
+``` console
+cd /opt/R/3.4.2/lib/R/etc
+sudo nano Renviron
+```
+
+
+
 ### 7.2 Edit the config file
 
 Add the following section to the config file
 
 ``` console
 [Packages]
-External = HilltopServer`
+External = HilltopServer
 ```
 
-Restart the server
+Restart the RStudio-Connect server
 
 `sudo systemctl restart rstudio-connect`
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -3,9 +3,10 @@
 |Property|Value|
 |:--|:--|
 |Target OS|Ubuntu 18.04.xx|
+|Privileges|sudo|
 |Reference| [RStudio Connect: Admin Guide](https://docs.rstudio.com/connect/admin/index.html)|
 |Compiled by|Sean Hodges|
-
+|Last updated|2019-06-15|
 ## Checklist
 
 - [ ] Install R
@@ -111,7 +112,7 @@ You will use `gdebi` to install Connect and its dependencies. It is installed vi
 sudo apt-get install gdebi-core
 ```
 
-**The instructions below relate to the installation of the 45 day trial version of RStudio Connect. Production version instructions are provided elsewhere**
+**The instructions below relate to the installation of the 45 day trial version of RStudio Connect as at May 2019.**
 You should have a `.deb` installer for RStudio Connect. It can be downloaded from the RStudio website (the link is provided by email when you register for the download). If you only have a link to this file, you can use `wget` to download the file to the current directory.
 
 ```console
@@ -126,6 +127,25 @@ sudo gdebi rstudio-connect_1.7.2.2-14_amd64.deb
 ```
 
 This will install Connect into `/opt/rstudio-connect/`, and create a new rstudio-connect user.
+
+**The instructions below relate to the installation of the Commercial version of RStudio Connect as at June 2019.**
+RStudio only provides (as at June 2019) a pre-built binary for the 64-bit architecture. Pre-install checklist:
+
+These steps will install RStudio Connect:
+
+```console
+cd /tmp
+wget https://s3.amazonaws.com/rstudio-connect/rstudio-connect_1.7.4.2-16_amd64.deb
+```
+
+Once the `.deb` file is available locally, run the following command to install RStudio Connect.
+
+``` console
+sudo gdebi rstudio-connect_1.7.4.2-16_amd64.deb
+```
+
+This will install Connect into `/opt/rstudio-connect/`, and create a new rstudio-connect user.
+
 
 ## 4. Edit RStudio Connect config file
 

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -13,6 +13,7 @@
 - [ ] Download & install RStudio Connect
 - [ ] Edit RStudio Connect config file
 - [ ] Test deployment
+- [ ] Adding the HilltopServer package
 
 ## 1. Install R
  Administrators of the RStudioConnect box should install the versions of R that they wish to support from source so that user content is run in an environment as close as possible to the development environment. This allows maintenance of multiple versions of R simultaneously and mitigates the risk associated with updating the version of R.
@@ -150,3 +151,19 @@ Restart RStudio Connect after altering the rstudio-connect.gcfg configuration fi
 
 
 ## 6. Production Configuration Settings 
+
+## 7. Setting up HilltopServer package
+HilltopServer is a proprietery software package that handles requests for timeseries data. Accessing timeseries data through HilltopServer is a necessary capability for Horizons.
+
+RStudioConnect expects to compile packages from source, but this is not possible for the HilltopServer package. The steps required to install this package are as follows
+
+### 7.1 Copy the Package
+
+### 7.2 Edit the config file
+
+Add the following section to the config file
+
+`[Packages]
+External = HilltopServer`
+
+

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -90,12 +90,12 @@ The following system dependencies are required by many common R packages and nea
 * `libblas-dev`
 * `libpack-dev`
 * `libudunits2-dev`
-* `libgdal`
+* `libgdal-dev`
 
 Typically, the following commands at the console will do the trick:
 
 ```console
-sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full libblas-dev libpack-dev libudunits2-dev libgdal
+sudo apt-get install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev texlive-full libblas-dev libpack-dev libudunits2-dev libgdal-dev
 sudo apt install openjdk-11-jdk
 sudo R CMD javareconf
 ```

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -17,8 +17,10 @@
 - [ ] Adding the HilltopServer package
 
 ## 1. Install R
- Administrators of the RStudioConnect box should install the versions of R that they wish to support from source so that user content is run in an environment as close as possible to the development environment. This allows maintenance of multiple versions of R simultaneously and mitigates the risk associated with updating the version of R.
- 
+Administrators of the RStudioConnect box should install the versions of R that they wish to support from source so that user content is run in an environment as close as possible to the development environment. This allows maintenance of multiple versions of R simultaneously and mitigates the risk associated with updating the version of R.
+
+Ensure that the `src` URI's in `sources.list` are uncommmented, as various libraries and packages will need to be built from source. Without this, the `sudo apt-get build-dep` will error.
+
 To build R from source, first, acquire the build dependencies for R.
 
 In Ubuntu, you can install build dependencies with

--- a/RStudioConnect.md
+++ b/RStudioConnect.md
@@ -181,23 +181,29 @@ sudo cp -r ~/HilltopServer 3.5/
 sudo cp -r ~/HilltopServer 3.6/
 ```
 
-3. Now, for each R environment that is installed, the path to the user libraries needs to be updated. 
+3. Now, for each R environment, edit the `Renviron` files: 
 
 ``` console
 cd /opt/R/3.4.2/lib/R/etc
 sudo nano Renviron
 ```
 
+Edit the `R_LIBS_USER` variable in the `Renviron` file, ensuring that any other entries for this variable are hashed out.
+
+`R_LIBS_USER=${R_LIBS_USERS-'/usr/local/share/rpkgs/3.4'}`
 
 
 ### 7.2 Edit the config file
 
-Add the following section to the config file
+As a final step, to make RStudio-Connect aware of the manually installed pacage, add the following section to the config file.
 
 ``` console
 [Packages]
 External = HilltopServer
 ```
+
+This setting will force RStudio-Connect to skip compilation when it strikes this package in a project that is being uploaded. Many `External = ` items can be added on new lines in this section.
+
 
 Restart the RStudio-Connect server
 


### PR DESCRIPTION
Changes to document how the HilltopServer R package needs to be configured so that RStudio-Connect can use it without complaining about trying to compile it.